### PR TITLE
Replace psycopg2-binary

### DIFF
--- a/env.ps1
+++ b/env.ps1
@@ -1,12 +1,12 @@
 $MD = "PES"
 $VCREDIST_REF = "https://aka.ms/vs/17/release/vc_redist.x64.exe"
-$ETCD_REF = "https://github.com/etcd-io/etcd/releases/download/v3.5.17/etcd-v3.5.17-windows-amd64.zip"
-$PATRONI_REF = "https://github.com/patroni/patroni/archive/refs/tags/v4.0.4.zip"
+$ETCD_REF = "https://github.com/etcd-io/etcd/releases/download/v3.5.18/etcd-v3.5.18-windows-amd64.zip"
+$PATRONI_REF = "https://github.com/patroni/patroni/archive/refs/tags/v4.0.5.zip"
 $MICRO_REF = "https://github.com/zyedidia/micro/releases/download/v2.0.14/micro-2.0.14-win64.zip"
 $WINSW_REF = "https://github.com/winsw/winsw/releases/download/v2.12.0/WinSW.NET461.exe"
 $VIP_REF = "https://github.com/cybertec-postgresql/vip-manager/releases/download/v3.0.0/vip-manager_3.0.0_Windows_x86_64.zip"
-$PGSQL_REF = "https://get.enterprisedb.com/postgresql/postgresql-17.2-1-windows-x64-binaries.zip"
-$PYTHON_REF = "https://www.python.org/ftp/python/3.13.1/python-3.13.1-amd64.exe"
+$PGSQL_REF = "https://get.enterprisedb.com/postgresql/postgresql-17.4-1-windows-x64-binaries.zip"
+$PYTHON_REF = "https://www.python.org/ftp/python/3.13.2/python-3.13.2-amd64.exe"
 # one should change python version in github action workflows when changed here
 
 $SEVENZIP = "C:\Program Files\7-Zip\7z.exe"

--- a/make.ps1
+++ b/make.ps1
@@ -102,7 +102,7 @@ function Get-PatroniPackages {
     Write-Host "`n--- Download PATRONI packages ---" -ForegroundColor blue
     Set-Location "$MD\patroni"
     & $PIP download -r requirements.txt -d .patroni-packages
-    & $PIP download pip pip_install setuptools wheel cdiff psycopg2-binary -d .patroni-packages
+    & $PIP download pip pip_install setuptools wheel cdiff psycopg-binary -d .patroni-packages
     Set-Location -Path "..\.."
     Write-Host "`n--- PATRONI packages downloaded ---" -ForegroundColor green
 }

--- a/src/install.ps1
+++ b/src/install.ps1
@@ -21,7 +21,7 @@ Write-Host "--- Python runtime installed ---`n" -ForegroundColor green
 
 Write-Host "--- Installing Patroni packages ---" -ForegroundColor blue
 pip3.exe install --no-index --find-links .patroni-packages -r requirements.txt
-pip3.exe install --no-index --find-links .patroni-packages psycopg2-binary
+pip3.exe install --no-index --find-links .patroni-packages psycopg-binary
 pip3.exe install --no-index --find-links .patroni-packages cdiff
 Set-Location '..'
 Write-Host "--- Patroni packages installed ---`n" -ForegroundColor green


### PR DESCRIPTION
`install.ps1` was erroring out with an unspecific error about missing VC++ redistributable error (or with a complaint about a missing `pg_config` executable).

This change is aimed to fix this.

Furthermore, a new release is necessary.  Bumped versions:
- PostgreSQL (fixed a CVE and a subsequent regression)
- etcd
- Patroni
- Python